### PR TITLE
Implement MVVM and MVP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ os: osx
 osx_image: xcode11
 language: swift
 script: 
-  - xcodebuild clean build test -project UIDesignPatternsChallenge.xcodeproj -scheme "CI" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -sdk iphonesimulator -destination "platform=iOS Simulator,OS=12.2,name=iPhone 8" ONLY_ACTIVE_ARCH=YES
+  - xcodebuild clean build test -project UIDesignPatternsChallenge.xcodeproj -scheme "CI" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -sdk iphonesimulator -destination "platform=iOS Simulator,OS=13.0,name=iPhone 11 Pro Max" ONLY_ACTIVE_ARCH=YES

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode10.2
+osx_image: xcode11
 language: swift
 script: 
   - xcodebuild clean build test -project UIDesignPatternsChallenge.xcodeproj -scheme "CI" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -sdk iphonesimulator -destination "platform=iOS Simulator,OS=12.2,name=iPhone 8" ONLY_ACTIVE_ARCH=YES

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ os: osx
 osx_image: xcode11
 language: swift
 script: 
-  - xcodebuild clean build test -project UIDesignPatternsChallenge.xcodeproj -scheme "CI" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -sdk iphonesimulator -destination "platform=iOS Simulator,OS=13.0,name=iPhone 11 Pro Max" ONLY_ACTIVE_ARCH=YES
+  - xcodebuild clean build test -project UIDesignPatternsChallenge.xcodeproj -scheme "CI" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -sdk iphonesimulator -destination "platform=iOS Simulator,OS=13.0,name=iPhone 8" ONLY_ACTIVE_ARCH=YES

--- a/MVC Module/Source/Feed Presentation/ro.lproj/Feed.strings
+++ b/MVC Module/Source/Feed Presentation/ro.lproj/Feed.strings
@@ -1,0 +1,3 @@
+
+"FEED_VIEW_TITLE" = "Fluxul meu";
+"FEED_VIEW_CONNECTION_ERROR" = "Nu s-a putut conecta la server";

--- a/MVC Module/Source/Feed UI/Controllers/FeedViewController.swift
+++ b/MVC Module/Source/Feed UI/Controllers/FeedViewController.swift
@@ -10,6 +10,10 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
 	var tableModel = [FeedImageCellController]() {
 		didSet { tableView.reloadData() }
 	}
+
+    public var errorView: ErrorView? {
+        return tableView.tableHeaderView as? ErrorView
+    }
 	
 	public override func viewDidLoad() {
 		super.viewDidLoad()

--- a/MVC Module/Source/Feed UI/Views/ErrorView.swift
+++ b/MVC Module/Source/Feed UI/Views/ErrorView.swift
@@ -5,37 +5,39 @@
 import UIKit
 
 public final class ErrorView: UIView {
-	@IBOutlet private var label: UILabel!
-	
-	public var message: String? {
-		get { return isVisible ? label.text : nil }
-	}
-	
-	private var isVisible: Bool {
-		return alpha > 0
-	}
-	
-	public override func awakeFromNib() {
-		super.awakeFromNib()
-		
-		label.text = nil
-		alpha = 0
-	}
-	
-	func show(message: String) {
-		self.label.text = message
-		
-		UIView.animate(withDuration: 0.25) {
-			self.alpha = 1
-		}
-	}
-	
-	@IBAction func hideMessage() {
-		UIView.animate(
-			withDuration: 0.25,
-			animations: { self.alpha = 0 },
-			completion: { completed in
-				if completed { self.label.text = nil }
-		})
-	}
+    @IBOutlet public var button: UIButton!
+
+    public var message: String? {
+        get { return isVisible ? button.title(for: .normal) : nil }
+    }
+
+    private var isVisible: Bool {
+        return alpha > 0
+    }
+
+    public override func awakeFromNib() {
+        super.awakeFromNib()
+
+        button.setTitle(nil, for: .normal)
+        alpha = 0
+    }
+
+    func show(message: String) {
+        self.button.setTitle(message, for: .normal)
+
+        UIView.animate(withDuration: 0.25) {
+            self.alpha = 1
+        }
+    }
+
+    @IBAction func hideMessage() {
+        UIView.animate(
+            withDuration: 0.25,
+            animations: { self.alpha = 0 },
+            completion: { completed in
+                if completed {
+                    self.button.setTitle(nil, for: .normal)
+                }
+        })
+    }
 }

--- a/MVC Module/Source/Feed UI/Views/ErrorView.swift
+++ b/MVC Module/Source/Feed UI/Views/ErrorView.swift
@@ -8,7 +8,7 @@ public final class ErrorView: UIView {
     @IBOutlet public var button: UIButton!
 
     public var message: String? {
-        get { return isVisible ? button.title(for: .normal) : nil }
+        isVisible ? button.title(for: .normal) : nil
     }
 
     private var isVisible: Bool {

--- a/MVC Module/Source/Feed UI/Views/Feed.storyboard
+++ b/MVC Module/Source/Feed UI/Views/Feed.storyboard
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1hh-nG-9OR">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1hh-nG-9OR">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,29 +19,31 @@
                             <rect key="frame" x="0.0" y="0.0" width="414" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m4a-GE-sBY">
-                                    <rect key="frame" x="8" y="8" width="398" height="18"/>
-                                    <viewLayoutGuide key="safeArea" id="RfT-kU-kzd"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pUU-YN-fiM">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="34"/>
+                                    <state key="normal" title="Error label">
+                                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </state>
+                                    <connections>
+                                        <action selector="hideMessage" destination="clu-9B-M8g" eventType="touchUpInside" id="zQi-QK-M6z"/>
+                                    </connections>
+                                </button>
                             </subviews>
                             <color key="backgroundColor" red="0.99951404330000004" green="0.41759261489999999" blue="0.4154433012" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <gestureRecognizers/>
                             <constraints>
-                                <constraint firstItem="m4a-GE-sBY" firstAttribute="top" secondItem="clu-9B-M8g" secondAttribute="top" constant="8" id="N9q-HI-XYp"/>
-                                <constraint firstAttribute="trailingMargin" secondItem="m4a-GE-sBY" secondAttribute="trailing" id="QqE-a4-c5n"/>
-                                <constraint firstItem="m4a-GE-sBY" firstAttribute="leading" secondItem="clu-9B-M8g" secondAttribute="leadingMargin" id="hcM-H0-YWr"/>
-                                <constraint firstAttribute="bottom" secondItem="m4a-GE-sBY" secondAttribute="bottom" constant="8" id="zmS-j0-eKt"/>
+                                <constraint firstAttribute="bottom" secondItem="pUU-YN-fiM" secondAttribute="bottom" id="09r-Fh-JkF"/>
+                                <constraint firstItem="pUU-YN-fiM" firstAttribute="top" secondItem="clu-9B-M8g" secondAttribute="top" id="2Yr-x5-I5R"/>
+                                <constraint firstAttribute="trailing" secondItem="pUU-YN-fiM" secondAttribute="trailing" id="DmX-Go-Hdb"/>
+                                <constraint firstItem="pUU-YN-fiM" firstAttribute="leading" secondItem="clu-9B-M8g" secondAttribute="leading" id="xrI-eg-hUj"/>
                             </constraints>
                             <connections>
-                                <outlet property="label" destination="m4a-GE-sBY" id="GLs-m1-rIC"/>
+                                <outlet property="button" destination="pUU-YN-fiM" id="hZO-fN-5kv"/>
                                 <outletCollection property="gestureRecognizers" destination="FYg-l9-JlU" appends="YES" id="KuZ-lS-3Ho"/>
                             </connections>
                         </view>
                         <view key="tableFooterView" contentMode="scaleToFill" id="pGT-Qn-vv2">
-                            <rect key="frame" x="0.0" y="642" width="414" height="16"/>
+                            <rect key="frame" x="0.0" y="670" width="414" height="16"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>

--- a/MVC Module/Source/Feed UI/Views/Helpers/UIView+Shimmering.swift
+++ b/MVC Module/Source/Feed UI/Views/Helpers/UIView+Shimmering.swift
@@ -15,7 +15,7 @@ extension UIView {
 		}
 		
 		get {
-			return layer.mask?.animation(forKey: shimmerAnimationKey) != nil
+			layer.mask?.animation(forKey: shimmerAnimationKey) != nil
 		}
 	}
 	

--- a/MVC Module/Tests/Feed UI/FeedUIIntegrationTests.swift
+++ b/MVC Module/Tests/Feed UI/FeedUIIntegrationTests.swift
@@ -91,6 +91,19 @@ final class FeedUIIntegrationTests: XCTestCase {
 		XCTAssertEqual(sut.errorMessage, nil)
 	}
 
+    func test_loadFeedCompletion_hidesErrorMessageOnErrorLabelTap() {
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoadingWithError(at: 0)
+
+        XCTAssertEqual(sut.errorMessage, localized("FEED_VIEW_CONNECTION_ERROR"))
+
+        sut.errorView?.button.simulateTap()
+
+        XCTAssertEqual(sut.errorMessage, nil)
+    }
+
 	func test_feedImageView_loadsImageURLWhenVisible() {
 		let image0 = makeImage(url: URL(string: "http://url-0.com")!)
 		let image1 = makeImage(url: URL(string: "http://url-1.com")!)

--- a/MVP Module/Source/Feed Presentation/FeedLoadingViewModel.swift
+++ b/MVP Module/Source/Feed Presentation/FeedLoadingViewModel.swift
@@ -2,7 +2,10 @@
 //  Copyright © 2019 Essential Developer. All rights reserved.
 //
 
+struct FeedErrorViewModel {
+    let errorMessage: String
+}
+
 struct FeedLoadingViewModel {
 	let isLoading: Bool
-    let errorMessage: String?
 }

--- a/MVP Module/Source/Feed Presentation/FeedLoadingViewModel.swift
+++ b/MVP Module/Source/Feed Presentation/FeedLoadingViewModel.swift
@@ -4,4 +4,5 @@
 
 struct FeedLoadingViewModel {
 	let isLoading: Bool
+    let errorMessage: String?
 }

--- a/MVP Module/Source/Feed Presentation/FeedPresenter.swift
+++ b/MVP Module/Source/Feed Presentation/FeedPresenter.swift
@@ -7,19 +7,24 @@ import FeedFeature
 
 protocol FeedLoadingView {
 	func display(_ viewModel: FeedLoadingViewModel)
-    func display(_ viewModel: FeedErrorViewModel)
 }
 
 protocol FeedView {
 	func display(_ viewModel: FeedViewModel)
 }
 
+protocol FeedErrorView {
+    func display(_ viewModel: FeedErrorViewModel)
+}
+
 final class FeedPresenter {
 	private let feedView: FeedView
+    private let feedErrorView: FeedErrorView
 	private let loadingView: FeedLoadingView
 	
-    init(feedView: FeedView, loadingView: FeedLoadingView) {
+    init(feedView: FeedView, feedErrorView: FeedErrorView, loadingView: FeedLoadingView) {
 		self.feedView = feedView
+        self.feedErrorView = feedErrorView
 		self.loadingView = loadingView
 	}
 
@@ -47,6 +52,6 @@ final class FeedPresenter {
 	}
 	
 	func didFinishLoadingFeed(with error: Error) {
-		loadingView.display(FeedErrorViewModel(errorMessage: loadError))
+		feedErrorView.display(FeedErrorViewModel(errorMessage: loadError))
 	}
 }

--- a/MVP Module/Source/Feed Presentation/FeedPresenter.swift
+++ b/MVP Module/Source/Feed Presentation/FeedPresenter.swift
@@ -7,6 +7,7 @@ import FeedFeature
 
 protocol FeedLoadingView {
 	func display(_ viewModel: FeedLoadingViewModel)
+    func display(_ viewModel: FeedErrorViewModel)
 }
 
 protocol FeedView {
@@ -17,7 +18,7 @@ final class FeedPresenter {
 	private let feedView: FeedView
 	private let loadingView: FeedLoadingView
 	
-	init(feedView: FeedView, loadingView: FeedLoadingView) {
+    init(feedView: FeedView, loadingView: FeedLoadingView) {
 		self.feedView = feedView
 		self.loadingView = loadingView
 	}
@@ -37,15 +38,15 @@ final class FeedPresenter {
     }
 
 	func didStartLoadingFeed() {
-		loadingView.display(FeedLoadingViewModel(isLoading: true, errorMessage: nil))
+		loadingView.display(FeedLoadingViewModel(isLoading: true))
 	}
 	
 	func didFinishLoadingFeed(with feed: [FeedImage]) {
 		feedView.display(FeedViewModel(feed: feed))
-		loadingView.display(FeedLoadingViewModel(isLoading: false, errorMessage: nil))
+		loadingView.display(FeedLoadingViewModel(isLoading: false))
 	}
 	
 	func didFinishLoadingFeed(with error: Error) {
-		loadingView.display(FeedLoadingViewModel(isLoading: false, errorMessage: loadError))
+		loadingView.display(FeedErrorViewModel(errorMessage: loadError))
 	}
 }

--- a/MVP Module/Source/Feed Presentation/FeedPresenter.swift
+++ b/MVP Module/Source/Feed Presentation/FeedPresenter.swift
@@ -29,16 +29,23 @@ final class FeedPresenter {
 			comment: "Title for the feed view")
 	}
 
+    var loadError: String {
+        return NSLocalizedString("FEED_VIEW_CONNECTION_ERROR",
+                                 tableName: "Feed",
+                                 bundle: Bundle(for: FeedPresenter.self),
+                                 comment: "Error message displayed when we can't load the image feed from the server")
+    }
+
 	func didStartLoadingFeed() {
-		loadingView.display(FeedLoadingViewModel(isLoading: true))
+		loadingView.display(FeedLoadingViewModel(isLoading: true, errorMessage: nil))
 	}
 	
 	func didFinishLoadingFeed(with feed: [FeedImage]) {
 		feedView.display(FeedViewModel(feed: feed))
-		loadingView.display(FeedLoadingViewModel(isLoading: false))
+		loadingView.display(FeedLoadingViewModel(isLoading: false, errorMessage: nil))
 	}
 	
 	func didFinishLoadingFeed(with error: Error) {
-		loadingView.display(FeedLoadingViewModel(isLoading: false))
+		loadingView.display(FeedLoadingViewModel(isLoading: false, errorMessage: loadError))
 	}
 }

--- a/MVP Module/Source/Feed Presentation/el.lproj/Feed.strings
+++ b/MVP Module/Source/Feed Presentation/el.lproj/Feed.strings
@@ -1,2 +1,3 @@
 
 "FEED_VIEW_TITLE" = "Το Feed μου";
+"FEED_VIEW_CONNECTION_ERROR" = "Δεν ήταν δυνατή η σύνδεση στο διακομιστή";

--- a/MVP Module/Source/Feed Presentation/en.lproj/Feed.strings
+++ b/MVP Module/Source/Feed Presentation/en.lproj/Feed.strings
@@ -1,2 +1,3 @@
 
 "FEED_VIEW_TITLE" = "My Feed";
+"FEED_VIEW_CONNECTION_ERROR" = "Couldn't connect to server";

--- a/MVP Module/Source/Feed Presentation/pt-BR.lproj/Feed.strings
+++ b/MVP Module/Source/Feed Presentation/pt-BR.lproj/Feed.strings
@@ -1,2 +1,3 @@
 
 "FEED_VIEW_TITLE" = "Meu Feed";
+"FEED_VIEW_CONNECTION_ERROR" = "Não foi possível conectar com o servidor";

--- a/MVP Module/Source/Feed Presentation/ro.lproj/Feed.strings
+++ b/MVP Module/Source/Feed Presentation/ro.lproj/Feed.strings
@@ -1,0 +1,2 @@
+
+"FEED_VIEW_TITLE" = "Fluxul meu";

--- a/MVP Module/Source/Feed Presentation/ro.lproj/Feed.strings
+++ b/MVP Module/Source/Feed Presentation/ro.lproj/Feed.strings
@@ -1,2 +1,3 @@
 
 "FEED_VIEW_TITLE" = "Fluxul meu";
+"FEED_VIEW_CONNECTION_ERROR" = "Nu s-a putut conecta la server";

--- a/MVP Module/Source/Feed UI/Composers/FeedUIComposer.swift
+++ b/MVP Module/Source/Feed UI/Composers/FeedUIComposer.swift
@@ -20,6 +20,7 @@ public final class FeedUIComposer {
 			feedView: FeedViewAdapter(
 				controller: feedController,
 				imageLoader: MainQueueDispatchDecorator(decoratee: imageLoader)),
+            feedErrorView: WeakRefVirtualProxy(feedController),
             loadingView: WeakRefVirtualProxy(feedController))
 		
 		return feedController

--- a/MVP Module/Source/Feed UI/Composers/FeedUIComposer.swift
+++ b/MVP Module/Source/Feed UI/Composers/FeedUIComposer.swift
@@ -20,7 +20,7 @@ public final class FeedUIComposer {
 			feedView: FeedViewAdapter(
 				controller: feedController,
 				imageLoader: MainQueueDispatchDecorator(decoratee: imageLoader)),
-			loadingView: WeakRefVirtualProxy(feedController))
+            loadingView: WeakRefVirtualProxy(feedController))
 		
 		return feedController
 	}

--- a/MVP Module/Source/Feed UI/Composers/WeakRefVirtualProxy.swift
+++ b/MVP Module/Source/Feed UI/Composers/WeakRefVirtualProxy.swift
@@ -16,7 +16,9 @@ extension WeakRefVirtualProxy: FeedLoadingView where T: FeedLoadingView {
 	func display(_ viewModel: FeedLoadingViewModel) {
 		object?.display(viewModel)
 	}
+}
 
+extension WeakRefVirtualProxy: FeedErrorView where T: FeedErrorView {
     func display(_ viewModel: FeedErrorViewModel) {
         object?.display(viewModel)
     }

--- a/MVP Module/Source/Feed UI/Composers/WeakRefVirtualProxy.swift
+++ b/MVP Module/Source/Feed UI/Composers/WeakRefVirtualProxy.swift
@@ -16,10 +16,14 @@ extension WeakRefVirtualProxy: FeedLoadingView where T: FeedLoadingView {
 	func display(_ viewModel: FeedLoadingViewModel) {
 		object?.display(viewModel)
 	}
+
+    func display(_ viewModel: FeedErrorViewModel) {
+        object?.display(viewModel)
+    }
 }
 
 extension WeakRefVirtualProxy: FeedImageView where T: FeedImageView, T.Image == UIImage {
-	func display(_ model: FeedImageViewModel<UIImage>) {
-		object?.display(model)
+	func display(_ viewModel: FeedImageViewModel<UIImage>) {
+		object?.display(viewModel)
 	}
 }

--- a/MVP Module/Source/Feed UI/Controllers/FeedViewController.swift
+++ b/MVP Module/Source/Feed UI/Controllers/FeedViewController.swift
@@ -32,7 +32,6 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     func display(_ viewModel: FeedErrorViewModel) {
         errorView?.show(message: viewModel.errorMessage)
         refreshControl?.endRefreshing()
-
     }
     
 	func display(_ viewModel: FeedLoadingViewModel) {

--- a/MVP Module/Source/Feed UI/Controllers/FeedViewController.swift
+++ b/MVP Module/Source/Feed UI/Controllers/FeedViewController.swift
@@ -28,15 +28,18 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     var errorView: ErrorView? {
         return tableView.tableHeaderView as? ErrorView
     }
-	
+
+    func display(_ viewModel: FeedErrorViewModel) {
+        errorView?.show(message: viewModel.errorMessage)
+        refreshControl?.endRefreshing()
+
+    }
+    
 	func display(_ viewModel: FeedLoadingViewModel) {
 		if viewModel.isLoading {
             errorView?.hideMessage()
 			refreshControl?.beginRefreshing()
 		} else {
-            if let errorMessage = viewModel.errorMessage {
-                errorView?.show(message: errorMessage)
-            }
 			refreshControl?.endRefreshing()
 		}
 	}

--- a/MVP Module/Source/Feed UI/Controllers/FeedViewController.swift
+++ b/MVP Module/Source/Feed UI/Controllers/FeedViewController.swift
@@ -8,7 +8,7 @@ protocol FeedViewControllerDelegate {
 	func didRequestFeedRefresh()
 }
 
-public final class FeedViewController: UITableViewController, UITableViewDataSourcePrefetching, FeedLoadingView {
+public final class FeedViewController: UITableViewController, UITableViewDataSourcePrefetching, FeedLoadingView, FeedErrorView {
 	var delegate: FeedViewControllerDelegate?
 	
 	var tableModel = [FeedImageCellController]() {

--- a/MVP Module/Source/Feed UI/Controllers/FeedViewController.swift
+++ b/MVP Module/Source/Feed UI/Controllers/FeedViewController.swift
@@ -24,11 +24,19 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
 	@IBAction private func refresh() {
 		delegate?.didRequestFeedRefresh()
 	}
+
+    var errorView: ErrorView? {
+        return tableView.tableHeaderView as? ErrorView
+    }
 	
 	func display(_ viewModel: FeedLoadingViewModel) {
 		if viewModel.isLoading {
+            errorView?.hideMessage()
 			refreshControl?.beginRefreshing()
 		} else {
+            if let errorMessage = viewModel.errorMessage {
+                errorView?.show(message: errorMessage)
+            }
 			refreshControl?.endRefreshing()
 		}
 	}

--- a/MVP Module/Source/Feed UI/Views/ErrorView.swift
+++ b/MVP Module/Source/Feed UI/Views/ErrorView.swift
@@ -8,7 +8,7 @@ public final class ErrorView: UIView {
 	@IBOutlet public var button: UIButton!
 	
 	public var message: String? {
-        get { return isVisible ? button.title(for: .normal) : nil }
+        isVisible ? button.title(for: .normal) : nil
 	}
 	
 	private var isVisible: Bool {

--- a/MVP Module/Source/Feed UI/Views/ErrorView.swift
+++ b/MVP Module/Source/Feed UI/Views/ErrorView.swift
@@ -5,25 +5,25 @@
 import UIKit
 
 public final class ErrorView: UIView {
-	@IBOutlet private var label: UILabel!
+	@IBOutlet public var button: UIButton!
 	
 	public var message: String? {
-		get { return isVisible ? label.text : nil }
+        isVisible ? button.title(for: .normal) : nil
 	}
 	
 	private var isVisible: Bool {
-		return alpha > 0
+		alpha > 0
 	}
 	
 	public override func awakeFromNib() {
 		super.awakeFromNib()
 		
-		label.text = nil
+        button.setTitle(nil, for: .normal)
 		alpha = 0
 	}
-	
+
 	func show(message: String) {
-		self.label.text = message
+        self.button.setTitle(message, for: .normal)
 		
 		UIView.animate(withDuration: 0.25) {
 			self.alpha = 1
@@ -35,7 +35,9 @@ public final class ErrorView: UIView {
 			withDuration: 0.25,
 			animations: { self.alpha = 0 },
 			completion: { completed in
-				if completed { self.label.text = nil }
+                if completed {
+                    self.button.setTitle(nil, for: .normal)
+                }
 		})
 	}
 }

--- a/MVP Module/Source/Feed UI/Views/ErrorView.swift
+++ b/MVP Module/Source/Feed UI/Views/ErrorView.swift
@@ -8,11 +8,11 @@ public final class ErrorView: UIView {
 	@IBOutlet public var button: UIButton!
 	
 	public var message: String? {
-        isVisible ? button.title(for: .normal) : nil
+        get { return isVisible ? button.title(for: .normal) : nil }
 	}
 	
 	private var isVisible: Bool {
-		alpha > 0
+		return alpha > 0
 	}
 	
 	public override func awakeFromNib() {

--- a/MVP Module/Source/Feed UI/Views/Feed.storyboard
+++ b/MVP Module/Source/Feed UI/Views/Feed.storyboard
@@ -39,6 +39,7 @@
                             </constraints>
                             <connections>
                                 <outlet property="label" destination="suv-TJ-iMJ" id="qlM-2y-JD5"/>
+                                <outletCollection property="gestureRecognizers" destination="OTf-1i-0n4" appends="YES" id="afD-9h-dla"/>
                             </connections>
                         </view>
                         <view key="tableFooterView" contentMode="scaleToFill" id="pGT-Qn-vv2">
@@ -168,6 +169,11 @@ Location</string>
                     </refreshControl>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RzX-Pc-Xwa" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="OTf-1i-0n4" userLabel="Hide Error Tap Gesture">
+                    <connections>
+                        <action selector="hideMessage" destination="clu-9B-M8g" id="OXI-Fi-Vb5"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="1105.7971014492755" y="-11.383928571428571"/>
         </scene>

--- a/MVP Module/Source/Feed UI/Views/Feed.storyboard
+++ b/MVP Module/Source/Feed UI/Views/Feed.storyboard
@@ -6,30 +6,49 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Feed View Controller-->
         <scene sceneID="mpX-1N-UIf">
             <objects>
-                <tableViewController id="1hh-nG-9OR" customClass="FeedViewController" customModule="EssentialFeediOS" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="1hh-nG-9OR" customClass="FeedViewController" customModule="MVP" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="9C2-mb-zX4">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <view key="tableHeaderView" contentMode="scaleToFill" id="clu-9B-M8g">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="16"/>
+                        <view key="tableHeaderView" contentMode="scaleToFill" id="clu-9B-M8g" customClass="ErrorView" customModule="MVP" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="suv-TJ-iMJ">
+                                    <rect key="frame" x="0.0" y="8" width="414" height="18"/>
+                                    <viewLayoutGuide key="safeArea" id="2XB-PI-BXl"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                            <color key="backgroundColor" red="1" green="0.41343292230000001" blue="0.54339731250000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            <constraints>
+                                <constraint firstItem="suv-TJ-iMJ" firstAttribute="top" secondItem="clu-9B-M8g" secondAttribute="top" constant="8" id="36i-M9-OGq"/>
+                                <constraint firstItem="suv-TJ-iMJ" firstAttribute="leading" secondItem="clu-9B-M8g" secondAttribute="leading" id="3UL-xv-GEA"/>
+                                <constraint firstAttribute="trailing" secondItem="suv-TJ-iMJ" secondAttribute="trailing" id="Bmw-9s-ohR"/>
+                                <constraint firstAttribute="bottom" secondItem="suv-TJ-iMJ" secondAttribute="bottom" constant="8" id="ITB-b0-bmC"/>
+                            </constraints>
+                            <connections>
+                                <outlet property="label" destination="suv-TJ-iMJ" id="qlM-2y-JD5"/>
+                            </connections>
                         </view>
                         <view key="tableFooterView" contentMode="scaleToFill" id="pGT-Qn-vv2">
-                            <rect key="frame" x="0.0" y="624" width="414" height="16"/>
+                            <rect key="frame" x="0.0" y="642" width="414" height="16"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="FeedImageCell" rowHeight="580" id="4Aa-lg-gTp" customClass="FeedImageCell" customModule="EssentialFeediOS" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="44" width="414" height="580"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="FeedImageCell" rowHeight="580" id="4Aa-lg-gTp" customClass="FeedImageCell" customModule="MVP" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="62" width="414" height="580"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="4Aa-lg-gTp" id="ZOf-kB-Mm6">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="580"/>

--- a/MVP Module/Source/Feed UI/Views/Feed.storyboard
+++ b/MVP Module/Source/Feed UI/Views/Feed.storyboard
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1hh-nG-9OR">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1hh-nG-9OR">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,28 +19,30 @@
                             <rect key="frame" x="0.0" y="0.0" width="414" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="suv-TJ-iMJ">
-                                    <rect key="frame" x="0.0" y="8" width="414" height="18"/>
-                                    <viewLayoutGuide key="safeArea" id="2XB-PI-BXl"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yQP-47-ylB">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="34"/>
+                                    <state key="normal" title="Error label">
+                                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </state>
+                                    <connections>
+                                        <action selector="hideMessage" destination="clu-9B-M8g" eventType="touchUpInside" id="bPz-9U-rA4"/>
+                                    </connections>
+                                </button>
                             </subviews>
                             <color key="backgroundColor" red="1" green="0.41343292230000001" blue="0.54339731250000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
-                                <constraint firstItem="suv-TJ-iMJ" firstAttribute="top" secondItem="clu-9B-M8g" secondAttribute="top" constant="8" id="36i-M9-OGq"/>
-                                <constraint firstItem="suv-TJ-iMJ" firstAttribute="leading" secondItem="clu-9B-M8g" secondAttribute="leading" id="3UL-xv-GEA"/>
-                                <constraint firstAttribute="trailing" secondItem="suv-TJ-iMJ" secondAttribute="trailing" id="Bmw-9s-ohR"/>
-                                <constraint firstAttribute="bottom" secondItem="suv-TJ-iMJ" secondAttribute="bottom" constant="8" id="ITB-b0-bmC"/>
+                                <constraint firstAttribute="bottom" secondItem="yQP-47-ylB" secondAttribute="bottom" id="2Az-9m-DWU"/>
+                                <constraint firstItem="yQP-47-ylB" firstAttribute="leading" secondItem="clu-9B-M8g" secondAttribute="leading" id="hC2-p2-Qo8"/>
+                                <constraint firstItem="yQP-47-ylB" firstAttribute="top" secondItem="clu-9B-M8g" secondAttribute="top" id="lIY-o2-J7D"/>
+                                <constraint firstAttribute="trailing" secondItem="yQP-47-ylB" secondAttribute="trailing" id="rEE-iu-U5g"/>
                             </constraints>
                             <connections>
-                                <outlet property="label" destination="suv-TJ-iMJ" id="qlM-2y-JD5"/>
+                                <outlet property="button" destination="yQP-47-ylB" id="DHJ-kF-DB1"/>
                                 <outletCollection property="gestureRecognizers" destination="OTf-1i-0n4" appends="YES" id="afD-9h-dla"/>
                             </connections>
                         </view>
                         <view key="tableFooterView" contentMode="scaleToFill" id="pGT-Qn-vv2">
-                            <rect key="frame" x="0.0" y="642" width="414" height="16"/>
+                            <rect key="frame" x="0.0" y="670" width="414" height="16"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>

--- a/MVP Module/Source/Feed UI/Views/Helpers/UIView+Shimmering.swift
+++ b/MVP Module/Source/Feed UI/Views/Helpers/UIView+Shimmering.swift
@@ -15,7 +15,7 @@ extension UIView {
 		}
 		
 		get {
-			return layer.mask?.animation(forKey: shimmerAnimationKey) != nil
+			layer.mask?.animation(forKey: shimmerAnimationKey) != nil
 		}
 	}
 	

--- a/MVP Module/Tests/Feed UI/FeedUIIntegrationTests.swift
+++ b/MVP Module/Tests/Feed UI/FeedUIIntegrationTests.swift
@@ -8,75 +8,75 @@ import MVP
 import FeedFeature
 
 final class FeedUIIntegrationTests: XCTestCase {
-	
-	func test_feedView_hasTitle() {
-		let (sut, _) = makeSUT()
-		
-		sut.loadViewIfNeeded()
-		
-		XCTAssertEqual(sut.title, localized("FEED_VIEW_TITLE"))
-	}
-	
-	func test_loadFeedActions_requestFeedFromLoader() {
-		let (sut, loader) = makeSUT()
-		XCTAssertEqual(loader.loadFeedCallCount, 0, "Expected no loading requests before view is loaded")
-		
-		sut.loadViewIfNeeded()
-		XCTAssertEqual(loader.loadFeedCallCount, 1, "Expected a loading request once view is loaded")
-		
-		sut.simulateUserInitiatedFeedReload()
-		XCTAssertEqual(loader.loadFeedCallCount, 2, "Expected another loading request once user initiates a reload")
-		
-		sut.simulateUserInitiatedFeedReload()
-		XCTAssertEqual(loader.loadFeedCallCount, 3, "Expected yet another loading request once user initiates another reload")
-	}
-	
-	func test_loadingFeedIndicator_isVisibleWhileLoadingFeed() {
-		let (sut, loader) = makeSUT()
-		
-		sut.loadViewIfNeeded()
-		XCTAssertTrue(sut.isShowingLoadingIndicator, "Expected loading indicator once view is loaded")
-		
-		loader.completeFeedLoading(at: 0)
-		XCTAssertFalse(sut.isShowingLoadingIndicator, "Expected no loading indicator once loading completes successfully")
-		
-		sut.simulateUserInitiatedFeedReload()
-		XCTAssertTrue(sut.isShowingLoadingIndicator, "Expected loading indicator once user initiates a reload")
-		
-		loader.completeFeedLoadingWithError(at: 1)
-		XCTAssertFalse(sut.isShowingLoadingIndicator, "Expected no loading indicator once user initiated loading completes with error")
-	}
 
-	func test_loadFeedCompletion_rendersSuccessfullyLoadedFeed() {
-		let image0 = makeImage(description: "a description", location: "a location")
-		let image1 = makeImage(description: nil, location: "another location")
-		let image2 = makeImage(description: "another description", location: nil)
-		let image3 = makeImage(description: nil, location: nil)
-		let (sut, loader) = makeSUT()
-		
-		sut.loadViewIfNeeded()
-		assertThat(sut, isRendering: [])
+    func test_feedView_hasTitle() {
+        let (sut, _) = makeSUT()
 
-		loader.completeFeedLoading(with: [image0], at: 0)
-		assertThat(sut, isRendering: [image0])
+        sut.loadViewIfNeeded()
 
-		sut.simulateUserInitiatedFeedReload()
-		loader.completeFeedLoading(with: [image0, image1, image2, image3], at: 1)
-		assertThat(sut, isRendering: [image0, image1, image2, image3])
-	}
-	
-	func test_loadFeedCompletion_doesNotAlterCurrentRenderingStateOnError() {
-		let image0 = makeImage()
-		let (sut, loader) = makeSUT()
-		
-		sut.loadViewIfNeeded()
-		loader.completeFeedLoading(with: [image0], at: 0)
-		assertThat(sut, isRendering: [image0])
-		
-		sut.simulateUserInitiatedFeedReload()
-		loader.completeFeedLoadingWithError(at: 1)
-		assertThat(sut, isRendering: [image0])
-	}
+        XCTAssertEqual(sut.title, localized("FEED_VIEW_TITLE"))
+    }
+
+    func test_loadFeedActions_requestFeedFromLoader() {
+        let (sut, loader) = makeSUT()
+        XCTAssertEqual(loader.loadFeedCallCount, 0, "Expected no loading requests before view is loaded")
+
+        sut.loadViewIfNeeded()
+        XCTAssertEqual(loader.loadFeedCallCount, 1, "Expected a loading request once view is loaded")
+
+        sut.simulateUserInitiatedFeedReload()
+        XCTAssertEqual(loader.loadFeedCallCount, 2, "Expected another loading request once user initiates a reload")
+
+        sut.simulateUserInitiatedFeedReload()
+        XCTAssertEqual(loader.loadFeedCallCount, 3, "Expected yet another loading request once user initiates another reload")
+    }
+
+    func test_loadingFeedIndicator_isVisibleWhileLoadingFeed() {
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        XCTAssertTrue(sut.isShowingLoadingIndicator, "Expected loading indicator once view is loaded")
+
+        loader.completeFeedLoading(at: 0)
+        XCTAssertFalse(sut.isShowingLoadingIndicator, "Expected no loading indicator once loading completes successfully")
+
+        sut.simulateUserInitiatedFeedReload()
+        XCTAssertTrue(sut.isShowingLoadingIndicator, "Expected loading indicator once user initiates a reload")
+
+        loader.completeFeedLoadingWithError(at: 1)
+        XCTAssertFalse(sut.isShowingLoadingIndicator, "Expected no loading indicator once user initiated loading completes with error")
+    }
+
+    func test_loadFeedCompletion_rendersSuccessfullyLoadedFeed() {
+        let image0 = makeImage(description: "a description", location: "a location")
+        let image1 = makeImage(description: nil, location: "another location")
+        let image2 = makeImage(description: "another description", location: nil)
+        let image3 = makeImage(description: nil, location: nil)
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        assertThat(sut, isRendering: [])
+
+        loader.completeFeedLoading(with: [image0], at: 0)
+        assertThat(sut, isRendering: [image0])
+
+        sut.simulateUserInitiatedFeedReload()
+        loader.completeFeedLoading(with: [image0, image1, image2, image3], at: 1)
+        assertThat(sut, isRendering: [image0, image1, image2, image3])
+    }
+
+    func test_loadFeedCompletion_doesNotAlterCurrentRenderingStateOnError() {
+        let image0 = makeImage()
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [image0], at: 0)
+        assertThat(sut, isRendering: [image0])
+
+        sut.simulateUserInitiatedFeedReload()
+        loader.completeFeedLoadingWithError(at: 1)
+        assertThat(sut, isRendering: [image0])
+    }
 
     func test_loadFeedCompletion_rendersErrorMessageOnErrorUntilNextReload() {
         let (sut, loader) = makeSUT()
@@ -91,7 +91,7 @@ final class FeedUIIntegrationTests: XCTestCase {
         XCTAssertEqual(sut.errorMessage, nil)
     }
 
-    func IGNOREtest_loadFeedCompletion_hidesErrorMessageOnErrorLabelTap() {
+    func test_loadFeedCompletion_hidesErrorMessageOnErrorLabelTap() {
         let (sut, loader) = makeSUT()
 
         sut.loadViewIfNeeded()
@@ -99,229 +99,230 @@ final class FeedUIIntegrationTests: XCTestCase {
 
         XCTAssertEqual(sut.errorMessage, localized("FEED_VIEW_CONNECTION_ERROR"))
 
-        sut.errorView?.simulateTapGesture()
+        sut.errorView?.button.simulateTap()
 
         XCTAssertEqual(sut.errorMessage, nil)
     }
 
-	func test_feedImageView_loadsImageURLWhenVisible() {
-		let image0 = makeImage(url: URL(string: "http://url-0.com")!)
-		let image1 = makeImage(url: URL(string: "http://url-1.com")!)
-		let (sut, loader) = makeSUT()
-		
-		sut.loadViewIfNeeded()
-		loader.completeFeedLoading(with: [image0, image1])
-		
-		XCTAssertEqual(loader.loadedImageURLs, [], "Expected no image URL requests until views become visible")
+    func test_feedImageView_loadsImageURLWhenVisible() {
+        let image0 = makeImage(url: URL(string: "http://url-0.com")!)
+        let image1 = makeImage(url: URL(string: "http://url-1.com")!)
+        let (sut, loader) = makeSUT()
 
-		sut.simulateFeedImageViewVisible(at: 0)
-		XCTAssertEqual(loader.loadedImageURLs, [image0.url], "Expected first image URL request once first view becomes visible")
-		
-		sut.simulateFeedImageViewVisible(at: 1)
-		XCTAssertEqual(loader.loadedImageURLs, [image0.url, image1.url], "Expected second image URL request once second view also becomes visible")
-	}
-	
-	func test_feedImageView_cancelsImageLoadingWhenNotVisibleAnymore() {
-		let image0 = makeImage(url: URL(string: "http://url-0.com")!)
-		let image1 = makeImage(url: URL(string: "http://url-1.com")!)
-		let (sut, loader) = makeSUT()
-		
-		sut.loadViewIfNeeded()
-		loader.completeFeedLoading(with: [image0, image1])
-		XCTAssertEqual(loader.cancelledImageURLs, [], "Expected no cancelled image URL requests until image is not visible")
-		
-		sut.simulateFeedImageViewNotVisible(at: 0)
-		XCTAssertEqual(loader.cancelledImageURLs, [image0.url], "Expected one cancelled image URL request once first image is not visible anymore")
-		
-		sut.simulateFeedImageViewNotVisible(at: 1)
-		XCTAssertEqual(loader.cancelledImageURLs, [image0.url, image1.url], "Expected two cancelled image URL requests once second image is also not visible anymore")
-	}
-	
-	func test_feedImageViewLoadingIndicator_isVisibleWhileLoadingImage() {
-		let (sut, loader) = makeSUT()
-		
-		sut.loadViewIfNeeded()
-		loader.completeFeedLoading(with: [makeImage(), makeImage()])
-		
-		let view0 = sut.simulateFeedImageViewVisible(at: 0)
-		let view1 = sut.simulateFeedImageViewVisible(at: 1)
-		XCTAssertEqual(view0?.isShowingImageLoadingIndicator, true, "Expected loading indicator for first view while loading first image")
-		XCTAssertEqual(view1?.isShowingImageLoadingIndicator, true, "Expected loading indicator for second view while loading second image")
-		
-		loader.completeImageLoading(at: 0)
-		XCTAssertEqual(view0?.isShowingImageLoadingIndicator, false, "Expected no loading indicator for first view once first image loading completes successfully")
-		XCTAssertEqual(view1?.isShowingImageLoadingIndicator, true, "Expected no loading indicator state change for second view once first image loading completes successfully")
-		
-		loader.completeImageLoadingWithError(at: 1)
-		XCTAssertEqual(view0?.isShowingImageLoadingIndicator, false, "Expected no loading indicator state change for first view once second image loading completes with error")
-		XCTAssertEqual(view1?.isShowingImageLoadingIndicator, false, "Expected no loading indicator for second view once second image loading completes with error")
-	}
-	
-	func test_feedImageView_rendersImageLoadedFromURL() {
-		let (sut, loader) = makeSUT()
-		
-		sut.loadViewIfNeeded()
-		loader.completeFeedLoading(with: [makeImage(), makeImage()])
-		
-		let view0 = sut.simulateFeedImageViewVisible(at: 0)
-		let view1 = sut.simulateFeedImageViewVisible(at: 1)
-		XCTAssertEqual(view0?.renderedImage, .none, "Expected no image for first view while loading first image")
-		XCTAssertEqual(view1?.renderedImage, .none, "Expected no image for second view while loading second image")
-		
-		let imageData0 = UIImage.make(withColor: .red).pngData()!
-		loader.completeImageLoading(with: imageData0, at: 0)
-		XCTAssertEqual(view0?.renderedImage, imageData0, "Expected image for first view once first image loading completes successfully")
-		XCTAssertEqual(view1?.renderedImage, .none, "Expected no image state change for second view once first image loading completes successfully")
-		
-		let imageData1 = UIImage.make(withColor: .blue).pngData()!
-		loader.completeImageLoading(with: imageData1, at: 1)
-		XCTAssertEqual(view0?.renderedImage, imageData0, "Expected no image state change for first view once second image loading completes successfully")
-		XCTAssertEqual(view1?.renderedImage, imageData1, "Expected image for second view once second image loading completes successfully")
-	}
-	
-	func test_feedImageViewRetryButton_isVisibleOnImageURLLoadError() {
-		let (sut, loader) = makeSUT()
-		
-		sut.loadViewIfNeeded()
-		loader.completeFeedLoading(with: [makeImage(), makeImage()])
-		
-		let view0 = sut.simulateFeedImageViewVisible(at: 0)
-		let view1 = sut.simulateFeedImageViewVisible(at: 1)
-		XCTAssertEqual(view0?.isShowingRetryAction, false, "Expected no retry action for first view while loading first image")
-		XCTAssertEqual(view1?.isShowingRetryAction, false, "Expected no retry action for second view while loading second image")
-		
-		let imageData = UIImage.make(withColor: .red).pngData()!
-		loader.completeImageLoading(with: imageData, at: 0)
-		XCTAssertEqual(view0?.isShowingRetryAction, false, "Expected no retry action for first view once first image loading completes successfully")
-		XCTAssertEqual(view1?.isShowingRetryAction, false, "Expected no retry action state change for second view once first image loading completes successfully")
-		
-		loader.completeImageLoadingWithError(at: 1)
-		XCTAssertEqual(view0?.isShowingRetryAction, false, "Expected no retry action state change for first view once second image loading completes with error")
-		XCTAssertEqual(view1?.isShowingRetryAction, true, "Expected retry action for second view once second image loading completes with error")
-	}
-	
-	func test_feedImageViewRetryButton_isVisibleOnInvalidImageData() {
-		let (sut, loader) = makeSUT()
-		
-		sut.loadViewIfNeeded()
-		loader.completeFeedLoading(with: [makeImage()])
-		
-		let view = sut.simulateFeedImageViewVisible(at: 0)
-		XCTAssertEqual(view?.isShowingRetryAction, false, "Expected no retry action while loading image")
-		
-		let invalidImageData = Data("invalid image data".utf8)
-		loader.completeImageLoading(with: invalidImageData, at: 0)
-		XCTAssertEqual(view?.isShowingRetryAction, true, "Expected retry action once image loading completes with invalid image data")
-	}
-	
-	func test_feedImageViewRetryAction_retriesImageLoad() {
-		let image0 = makeImage(url: URL(string: "http://url-0.com")!)
-		let image1 = makeImage(url: URL(string: "http://url-1.com")!)
-		let (sut, loader) = makeSUT()
-		
-		sut.loadViewIfNeeded()
-		loader.completeFeedLoading(with: [image0, image1])
-		
-		let view0 = sut.simulateFeedImageViewVisible(at: 0)
-		let view1 = sut.simulateFeedImageViewVisible(at: 1)
-		XCTAssertEqual(loader.loadedImageURLs, [image0.url, image1.url], "Expected two image URL request for the two visible views")
-		
-		loader.completeImageLoadingWithError(at: 0)
-		loader.completeImageLoadingWithError(at: 1)
-		XCTAssertEqual(loader.loadedImageURLs, [image0.url, image1.url], "Expected only two image URL requests before retry action")
-		
-		view0?.simulateRetryAction()
-		XCTAssertEqual(loader.loadedImageURLs, [image0.url, image1.url, image0.url], "Expected third imageURL request after first view retry action")
-		
-		view1?.simulateRetryAction()
-		XCTAssertEqual(loader.loadedImageURLs, [image0.url, image1.url, image0.url, image1.url], "Expected fourth imageURL request after second view retry action")
-	}
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [image0, image1])
 
-	func test_feedImageView_preloadsImageURLWhenNearVisible() {
-		let image0 = makeImage(url: URL(string: "http://url-0.com")!)
-		let image1 = makeImage(url: URL(string: "http://url-1.com")!)
-		let (sut, loader) = makeSUT()
-		
-		sut.loadViewIfNeeded()
-		loader.completeFeedLoading(with: [image0, image1])
-		XCTAssertEqual(loader.loadedImageURLs, [], "Expected no image URL requests until image is near visible")
-		
-		sut.simulateFeedImageViewNearVisible(at: 0)
-		XCTAssertEqual(loader.loadedImageURLs, [image0.url], "Expected first image URL request once first image is near visible")
-		
-		sut.simulateFeedImageViewNearVisible(at: 1)
-		XCTAssertEqual(loader.loadedImageURLs, [image0.url, image1.url], "Expected second image URL request once second image is near visible")
-	}
-	
-	func test_feedImageView_cancelsImageURLPreloadingWhenNotNearVisibleAnymore() {
-		let image0 = makeImage(url: URL(string: "http://url-0.com")!)
-		let image1 = makeImage(url: URL(string: "http://url-1.com")!)
-		let (sut, loader) = makeSUT()
-		
-		sut.loadViewIfNeeded()
-		loader.completeFeedLoading(with: [image0, image1])
-		XCTAssertEqual(loader.cancelledImageURLs, [], "Expected no cancelled image URL requests until image is not near visible")
-		
-		sut.simulateFeedImageViewNotNearVisible(at: 0)
-		XCTAssertEqual(loader.cancelledImageURLs, [image0.url], "Expected first cancelled image URL request once first image is not near visible anymore")
-		
-		sut.simulateFeedImageViewNotNearVisible(at: 1)
-		XCTAssertEqual(loader.cancelledImageURLs, [image0.url, image1.url], "Expected second cancelled image URL request once second image is not near visible anymore")
-	}
-	
-	func test_feedImageView_doesNotRenderLoadedImageWhenNotVisibleAnymore() {
-		let (sut, loader) = makeSUT()
-		sut.loadViewIfNeeded()
-		loader.completeFeedLoading(with: [makeImage()])
+        XCTAssertEqual(loader.loadedImageURLs, [], "Expected no image URL requests until views become visible")
 
-		let view = sut.simulateFeedImageViewNotVisible(at: 0)
-		loader.completeImageLoading(with: anyImageData())
-		
-		XCTAssertNil(view?.renderedImage, "Expected no rendered image when an image load finishes after the view is not visible anymore")
-	}
-	
-	func test_loadFeedCompletion_dispatchesFromBackgroundToMainThread() {
-		let (sut, loader) = makeSUT()
-		sut.loadViewIfNeeded()
+        sut.simulateFeedImageViewVisible(at: 0)
+        XCTAssertEqual(loader.loadedImageURLs, [image0.url], "Expected first image URL request once first view becomes visible")
 
-		let exp = expectation(description: "Wait for background queue")
-		DispatchQueue.global().async {
-			loader.completeFeedLoading(at: 0)
-			exp.fulfill()
-		}
-		wait(for: [exp], timeout: 1.0)
-	}
-	
-	func test_loadImageDataCompletion_dispatchesFromBackgroundToMainThread() {
-		let (sut, loader) = makeSUT()
-		
-		sut.loadViewIfNeeded()
-		loader.completeFeedLoading(with: [makeImage()])
-		_ = sut.simulateFeedImageViewVisible(at: 0)
-		
-		let exp = expectation(description: "Wait for background queue")
-		DispatchQueue.global().async {
-			loader.completeImageLoading(with: self.anyImageData(), at: 0)
-			exp.fulfill()
-		}
-		wait(for: [exp], timeout: 1.0)
-	}
-	
-	// MARK: - Helpers
-	
-	private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedViewController, loader: LoaderSpy) {
-		let loader = LoaderSpy()
-		let sut = FeedUIComposer.feedComposedWith(feedLoader: loader, imageLoader: loader)
-		trackForMemoryLeaks(loader, file: file, line: line)
-		trackForMemoryLeaks(sut, file: file, line: line)
-		return (sut, loader)
-	}
-	
-	private func makeImage(description: String? = nil, location: String? = nil, url: URL = URL(string: "http://any-url.com")!) -> FeedImage {
-		return FeedImage(id: UUID(), description: description, location: location, url: url)
-	}
+        sut.simulateFeedImageViewVisible(at: 1)
+        XCTAssertEqual(loader.loadedImageURLs, [image0.url, image1.url], "Expected second image URL request once second view also becomes visible")
+    }
 
-	private func anyImageData() -> Data {
-		return UIImage.make(withColor: .red).pngData()!
-	}
+    func test_feedImageView_cancelsImageLoadingWhenNotVisibleAnymore() {
+        let image0 = makeImage(url: URL(string: "http://url-0.com")!)
+        let image1 = makeImage(url: URL(string: "http://url-1.com")!)
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [image0, image1])
+        XCTAssertEqual(loader.cancelledImageURLs, [], "Expected no cancelled image URL requests until image is not visible")
+
+        sut.simulateFeedImageViewNotVisible(at: 0)
+        XCTAssertEqual(loader.cancelledImageURLs, [image0.url], "Expected one cancelled image URL request once first image is not visible anymore")
+
+        sut.simulateFeedImageViewNotVisible(at: 1)
+        XCTAssertEqual(loader.cancelledImageURLs, [image0.url, image1.url], "Expected two cancelled image URL requests once second image is also not visible anymore")
+    }
+
+    func test_feedImageViewLoadingIndicator_isVisibleWhileLoadingImage() {
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [makeImage(), makeImage()])
+
+        let view0 = sut.simulateFeedImageViewVisible(at: 0)
+        let view1 = sut.simulateFeedImageViewVisible(at: 1)
+        XCTAssertEqual(view0?.isShowingImageLoadingIndicator, true, "Expected loading indicator for first view while loading first image")
+        XCTAssertEqual(view1?.isShowingImageLoadingIndicator, true, "Expected loading indicator for second view while loading second image")
+
+        loader.completeImageLoading(at: 0)
+        XCTAssertEqual(view0?.isShowingImageLoadingIndicator, false, "Expected no loading indicator for first view once first image loading completes successfully")
+        XCTAssertEqual(view1?.isShowingImageLoadingIndicator, true, "Expected no loading indicator state change for second view once first image loading completes successfully")
+
+        loader.completeImageLoadingWithError(at: 1)
+        XCTAssertEqual(view0?.isShowingImageLoadingIndicator, false, "Expected no loading indicator state change for first view once second image loading completes with error")
+        XCTAssertEqual(view1?.isShowingImageLoadingIndicator, false, "Expected no loading indicator for second view once second image loading completes with error")
+    }
+
+    func test_feedImageView_rendersImageLoadedFromURL() {
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [makeImage(), makeImage()])
+
+        let view0 = sut.simulateFeedImageViewVisible(at: 0)
+        let view1 = sut.simulateFeedImageViewVisible(at: 1)
+        XCTAssertEqual(view0?.renderedImage, .none, "Expected no image for first view while loading first image")
+        XCTAssertEqual(view1?.renderedImage, .none, "Expected no image for second view while loading second image")
+
+        let imageData0 = UIImage.make(withColor: .red).pngData()!
+        loader.completeImageLoading(with: imageData0, at: 0)
+        XCTAssertEqual(view0?.renderedImage, imageData0, "Expected image for first view once first image loading completes successfully")
+        XCTAssertEqual(view1?.renderedImage, .none, "Expected no image state change for second view once first image loading completes successfully")
+
+        let imageData1 = UIImage.make(withColor: .blue).pngData()!
+        loader.completeImageLoading(with: imageData1, at: 1)
+        XCTAssertEqual(view0?.renderedImage, imageData0, "Expected no image state change for first view once second image loading completes successfully")
+        XCTAssertEqual(view1?.renderedImage, imageData1, "Expected image for second view once second image loading completes successfully")
+    }
+
+    func test_feedImageViewRetryButton_isVisibleOnImageURLLoadError() {
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [makeImage(), makeImage()])
+
+        let view0 = sut.simulateFeedImageViewVisible(at: 0)
+        let view1 = sut.simulateFeedImageViewVisible(at: 1)
+        XCTAssertEqual(view0?.isShowingRetryAction, false, "Expected no retry action for first view while loading first image")
+        XCTAssertEqual(view1?.isShowingRetryAction, false, "Expected no retry action for second view while loading second image")
+
+        let imageData = UIImage.make(withColor: .red).pngData()!
+        loader.completeImageLoading(with: imageData, at: 0)
+        XCTAssertEqual(view0?.isShowingRetryAction, false, "Expected no retry action for first view once first image loading completes successfully")
+        XCTAssertEqual(view1?.isShowingRetryAction, false, "Expected no retry action state change for second view once first image loading completes successfully")
+
+        loader.completeImageLoadingWithError(at: 1)
+        XCTAssertEqual(view0?.isShowingRetryAction, false, "Expected no retry action state change for first view once second image loading completes with error")
+        XCTAssertEqual(view1?.isShowingRetryAction, true, "Expected retry action for second view once second image loading completes with error")
+    }
+
+    func test_feedImageViewRetryButton_isVisibleOnInvalidImageData() {
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [makeImage()])
+
+        let view = sut.simulateFeedImageViewVisible(at: 0)
+        XCTAssertEqual(view?.isShowingRetryAction, false, "Expected no retry action while loading image")
+
+        let invalidImageData = Data("invalid image data".utf8)
+        loader.completeImageLoading(with: invalidImageData, at: 0)
+        XCTAssertEqual(view?.isShowingRetryAction, true, "Expected retry action once image loading completes with invalid image data")
+    }
+
+    func test_feedImageViewRetryAction_retriesImageLoad() {
+        let image0 = makeImage(url: URL(string: "http://url-0.com")!)
+        let image1 = makeImage(url: URL(string: "http://url-1.com")!)
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [image0, image1])
+
+        let view0 = sut.simulateFeedImageViewVisible(at: 0)
+        let view1 = sut.simulateFeedImageViewVisible(at: 1)
+        XCTAssertEqual(loader.loadedImageURLs, [image0.url, image1.url], "Expected two image URL request for the two visible views")
+
+        loader.completeImageLoadingWithError(at: 0)
+        loader.completeImageLoadingWithError(at: 1)
+        XCTAssertEqual(loader.loadedImageURLs, [image0.url, image1.url], "Expected only two image URL requests before retry action")
+
+        view0?.simulateRetryAction()
+        XCTAssertEqual(loader.loadedImageURLs, [image0.url, image1.url, image0.url], "Expected third imageURL request after first view retry action")
+
+        view1?.simulateRetryAction()
+        XCTAssertEqual(loader.loadedImageURLs, [image0.url, image1.url, image0.url, image1.url], "Expected fourth imageURL request after second view retry action")
+    }
+
+    func test_feedImageView_preloadsImageURLWhenNearVisible() {
+        let image0 = makeImage(url: URL(string: "http://url-0.com")!)
+        let image1 = makeImage(url: URL(string: "http://url-1.com")!)
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [image0, image1])
+        XCTAssertEqual(loader.loadedImageURLs, [], "Expected no image URL requests until image is near visible")
+
+        sut.simulateFeedImageViewNearVisible(at: 0)
+        XCTAssertEqual(loader.loadedImageURLs, [image0.url], "Expected first image URL request once first image is near visible")
+
+        sut.simulateFeedImageViewNearVisible(at: 1)
+        XCTAssertEqual(loader.loadedImageURLs, [image0.url, image1.url], "Expected second image URL request once second image is near visible")
+    }
+
+    func test_feedImageView_cancelsImageURLPreloadingWhenNotNearVisibleAnymore() {
+        let image0 = makeImage(url: URL(string: "http://url-0.com")!)
+        let image1 = makeImage(url: URL(string: "http://url-1.com")!)
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [image0, image1])
+        XCTAssertEqual(loader.cancelledImageURLs, [], "Expected no cancelled image URL requests until image is not near visible")
+
+        sut.simulateFeedImageViewNotNearVisible(at: 0)
+        XCTAssertEqual(loader.cancelledImageURLs, [image0.url], "Expected first cancelled image URL request once first image is not near visible anymore")
+
+        sut.simulateFeedImageViewNotNearVisible(at: 1)
+        XCTAssertEqual(loader.cancelledImageURLs, [image0.url, image1.url], "Expected second cancelled image URL request once second image is not near visible anymore")
+    }
+
+    func test_feedImageView_doesNotRenderLoadedImageWhenNotVisibleAnymore() {
+        let (sut, loader) = makeSUT()
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [makeImage()])
+
+        let view = sut.simulateFeedImageViewNotVisible(at: 0)
+        loader.completeImageLoading(with: anyImageData())
+
+        XCTAssertNil(view?.renderedImage, "Expected no rendered image when an image load finishes after the view is not visible anymore")
+    }
+
+    func test_loadFeedCompletion_dispatchesFromBackgroundToMainThread() {
+        let (sut, loader) = makeSUT()
+        sut.loadViewIfNeeded()
+
+        let exp = expectation(description: "Wait for background queue")
+        DispatchQueue.global().async {
+            loader.completeFeedLoading(at: 0)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    func test_loadImageDataCompletion_dispatchesFromBackgroundToMainThread() {
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [makeImage()])
+        _ = sut.simulateFeedImageViewVisible(at: 0)
+
+        let exp = expectation(description: "Wait for background queue")
+        DispatchQueue.global().async {
+            loader.completeImageLoading(with: self.anyImageData(), at: 0)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    // MARK: - Helpers
+
+    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedViewController, loader: LoaderSpy) {
+        let loader = LoaderSpy()
+        let sut = FeedUIComposer.feedComposedWith(feedLoader: loader, imageLoader: loader)
+        trackForMemoryLeaks(loader, file: file, line: line)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        return (sut, loader)
+    }
+
+    private func makeImage(description: String? = nil, location: String? = nil, url: URL = URL(string: "http://any-url.com")!) -> FeedImage {
+        return FeedImage(id: UUID(), description: description, location: location, url: url)
+    }
+
+    private func anyImageData() -> Data {
+        return UIImage.make(withColor: .red).pngData()!
+    }
 }
+

--- a/MVP Module/Tests/Feed UI/FeedUIIntegrationTests.swift
+++ b/MVP Module/Tests/Feed UI/FeedUIIntegrationTests.swift
@@ -78,6 +78,19 @@ final class FeedUIIntegrationTests: XCTestCase {
 		assertThat(sut, isRendering: [image0])
 	}
 
+    func test_loadFeedCompletion_rendersErrorMessageOnErrorUntilNextReload() {
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        XCTAssertEqual(sut.errorMessage, nil)
+
+        loader.completeFeedLoadingWithError(at: 0)
+        XCTAssertEqual(sut.errorMessage, localized("FEED_VIEW_CONNECTION_ERROR"))
+
+        sut.simulateUserInitiatedFeedReload()
+        XCTAssertEqual(sut.errorMessage, nil)
+    }
+
 	func test_feedImageView_loadsImageURLWhenVisible() {
 		let image0 = makeImage(url: URL(string: "http://url-0.com")!)
 		let image1 = makeImage(url: URL(string: "http://url-1.com")!)

--- a/MVP Module/Tests/Feed UI/FeedUIIntegrationTests.swift
+++ b/MVP Module/Tests/Feed UI/FeedUIIntegrationTests.swift
@@ -91,6 +91,19 @@ final class FeedUIIntegrationTests: XCTestCase {
         XCTAssertEqual(sut.errorMessage, nil)
     }
 
+    func IGNOREtest_loadFeedCompletion_hidesErrorMessageOnErrorLabelTap() {
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoadingWithError(at: 0)
+
+        XCTAssertEqual(sut.errorMessage, localized("FEED_VIEW_CONNECTION_ERROR"))
+
+        sut.errorView?.simulateTapGesture()
+
+        XCTAssertEqual(sut.errorMessage, nil)
+    }
+
 	func test_feedImageView_loadsImageURLWhenVisible() {
 		let image0 = makeImage(url: URL(string: "http://url-0.com")!)
 		let image1 = makeImage(url: URL(string: "http://url-1.com")!)

--- a/MVP Module/Tests/Feed UI/Helpers/FeedViewController+TestHelpers.swift
+++ b/MVP Module/Tests/Feed UI/Helpers/FeedViewController+TestHelpers.swift
@@ -39,7 +39,12 @@ extension FeedViewController {
 		let index = IndexPath(row: row, section: feedImagesSection)
 		ds?.tableView?(tableView, cancelPrefetchingForRowsAt: [index])
 	}
-	
+
+    var errorMessage: String? {
+        let errorView = tableView.tableHeaderView as? ErrorView
+        return errorView?.message
+    }
+    
 	var isShowingLoadingIndicator: Bool {
 		return refreshControl?.isRefreshing == true
 	}

--- a/MVP Module/Tests/Feed UI/Helpers/FeedViewController+TestHelpers.swift
+++ b/MVP Module/Tests/Feed UI/Helpers/FeedViewController+TestHelpers.swift
@@ -40,8 +40,15 @@ extension FeedViewController {
 		ds?.tableView?(tableView, cancelPrefetchingForRowsAt: [index])
 	}
 
+    func simulateUserTapOnView(_ view: UIView?) {
+        view?.simulateTapGesture()
+    }
+
+    var errorView: ErrorView? {
+        return tableView.tableHeaderView as? ErrorView
+    }
+
     var errorMessage: String? {
-        let errorView = tableView.tableHeaderView as? ErrorView
         return errorView?.message
     }
     

--- a/MVP Module/Tests/Feed UI/Helpers/UIView+TestHelpers.swift
+++ b/MVP Module/Tests/Feed UI/Helpers/UIView+TestHelpers.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright © 2019 Essential Developer. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+    func simulateTapGesture() {
+        let tapGestureRecognizers = self.gestureRecognizers?.filter { $0 is UITapGestureRecognizer }
+        tapGestureRecognizers?.forEach {
+
+            // Not working :(
+            let touch = UITouch()
+            let event = UIEvent()
+
+            $0.touchesBegan(Set([touch]), with: event)
+            $0.touchesEnded(Set([touch]), with: event)
+        }
+    }
+}
+

--- a/MVVM Module/Source/Feed Presentation/FeedViewModel.swift
+++ b/MVVM Module/Source/Feed Presentation/FeedViewModel.swift
@@ -21,16 +21,28 @@ final class FeedViewModel {
 			comment: "Title for the feed view")
 	}
 
+    var loadError: String {
+        return NSLocalizedString("FEED_VIEW_CONNECTION_ERROR",
+                                 tableName: "Feed",
+                                 bundle: Bundle(for: FeedViewModel.self),
+                                 comment: "Error message displayed when we can't load the image feed from the server")
+    }
+
 	var onLoadingStateChange: Observer<Bool>?
 	var onFeedLoad: Observer<[FeedImage]>?
+    var onLoadingError: Observer<String>?
 	
 	func loadFeed() {
 		onLoadingStateChange?(true)
 		feedLoader.load { [weak self] result in
-			if let feed = try? result.get() {
-				self?.onFeedLoad?(feed)
-			}
-			self?.onLoadingStateChange?(false)
+            guard let self = self else { return }
+
+            if let feed = try? result.get() {
+				self.onFeedLoad?(feed)
+            } else {
+                self.onLoadingError?(self.loadError)
+            }
+			self.onLoadingStateChange?(false)
 		}
 	}
 }

--- a/MVVM Module/Source/Feed Presentation/el.lproj/Feed.strings
+++ b/MVVM Module/Source/Feed Presentation/el.lproj/Feed.strings
@@ -1,2 +1,3 @@
 
 "FEED_VIEW_TITLE" = "Το Feed μου";
+"FEED_VIEW_CONNECTION_ERROR" = "Δεν ήταν δυνατή η σύνδεση στο διακομιστή";

--- a/MVVM Module/Source/Feed Presentation/en.lproj/Feed.strings
+++ b/MVVM Module/Source/Feed Presentation/en.lproj/Feed.strings
@@ -1,2 +1,3 @@
 
 "FEED_VIEW_TITLE" = "My Feed";
+"FEED_VIEW_CONNECTION_ERROR" = "Couldn't connect to server";

--- a/MVVM Module/Source/Feed Presentation/pt-BR.lproj/Feed.strings
+++ b/MVVM Module/Source/Feed Presentation/pt-BR.lproj/Feed.strings
@@ -1,2 +1,3 @@
 
 "FEED_VIEW_TITLE" = "Meu Feed";
+"FEED_VIEW_CONNECTION_ERROR" = "Não foi possível conectar com o servidor";

--- a/MVVM Module/Source/Feed Presentation/ro.lproj/Feed.strings
+++ b/MVVM Module/Source/Feed Presentation/ro.lproj/Feed.strings
@@ -1,0 +1,2 @@
+
+"FEED_VIEW_TITLE" = "Fluxul meu";

--- a/MVVM Module/Source/Feed Presentation/ro.lproj/Feed.strings
+++ b/MVVM Module/Source/Feed Presentation/ro.lproj/Feed.strings
@@ -1,2 +1,3 @@
 
 "FEED_VIEW_TITLE" = "Fluxul meu";
+"FEED_VIEW_CONNECTION_ERROR" = "Nu s-a putut conecta la server";

--- a/MVVM Module/Source/Feed UI/Controllers/FeedViewController.swift
+++ b/MVVM Module/Source/Feed UI/Controllers/FeedViewController.swift
@@ -23,7 +23,7 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
 		viewModel?.loadFeed()
 	}
 
-    var errorView: ErrorView? {
+    public var errorView: ErrorView? {
         return tableView.tableHeaderView as? ErrorView
     }
 	

--- a/MVVM Module/Source/Feed UI/Controllers/FeedViewController.swift
+++ b/MVVM Module/Source/Feed UI/Controllers/FeedViewController.swift
@@ -22,15 +22,23 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
 	@IBAction private func refresh() {
 		viewModel?.loadFeed()
 	}
+
+    var errorView: ErrorView? {
+        return tableView.tableHeaderView as? ErrorView
+    }
 	
 	func bind() {
 		viewModel?.onLoadingStateChange = { [weak self] isLoading in
-			if isLoading {
-				self?.refreshControl?.beginRefreshing()
+            if isLoading {
+                self?.errorView?.hideMessage()
+                self?.refreshControl?.beginRefreshing()
 			} else {
 				self?.refreshControl?.endRefreshing()
 			}
 		}
+        viewModel?.onLoadingError = { [weak self] loadError in
+            self?.errorView?.show(message: loadError)
+        }
 	}
 
 	public override func viewDidLayoutSubviews() {

--- a/MVVM Module/Source/Feed UI/Views/ErrorView.swift
+++ b/MVVM Module/Source/Feed UI/Views/ErrorView.swift
@@ -41,4 +41,3 @@ public final class ErrorView: UIView {
         })
     }
 }
-

--- a/MVVM Module/Source/Feed UI/Views/ErrorView.swift
+++ b/MVVM Module/Source/Feed UI/Views/ErrorView.swift
@@ -5,37 +5,40 @@
 import UIKit
 
 public final class ErrorView: UIView {
-	@IBOutlet private var label: UILabel!
-	
-	public var message: String? {
-		get { return isVisible ? label.text : nil }
-	}
-	
-	private var isVisible: Bool {
-		return alpha > 0
-	}
-	
-	public override func awakeFromNib() {
-		super.awakeFromNib()
-		
-		label.text = nil
-		alpha = 0
-	}
-	
-	func show(message: String) {
-		self.label.text = message
-		
-		UIView.animate(withDuration: 0.25) {
-			self.alpha = 1
-		}
-	}
-	
-	@IBAction func hideMessage() {
-		UIView.animate(
-			withDuration: 0.25,
-			animations: { self.alpha = 0 },
-			completion: { completed in
-				if completed { self.label.text = nil }
-		})
-	}
+    @IBOutlet public var button: UIButton!
+
+    public var message: String? {
+        get { return isVisible ? button.title(for: .normal) : nil }
+    }
+
+    private var isVisible: Bool {
+        return alpha > 0
+    }
+
+    public override func awakeFromNib() {
+        super.awakeFromNib()
+
+        button.setTitle(nil, for: .normal)
+        alpha = 0
+    }
+
+    func show(message: String) {
+        self.button.setTitle(message, for: .normal)
+
+        UIView.animate(withDuration: 0.25) {
+            self.alpha = 1
+        }
+    }
+
+    @IBAction func hideMessage() {
+        UIView.animate(
+            withDuration: 0.25,
+            animations: { self.alpha = 0 },
+            completion: { completed in
+                if completed {
+                    self.button.setTitle(nil, for: .normal)
+                }
+        })
+    }
 }
+

--- a/MVVM Module/Source/Feed UI/Views/ErrorView.swift
+++ b/MVVM Module/Source/Feed UI/Views/ErrorView.swift
@@ -8,7 +8,7 @@ public final class ErrorView: UIView {
     @IBOutlet public var button: UIButton!
 
     public var message: String? {
-        get { return isVisible ? button.title(for: .normal) : nil }
+        isVisible ? button.title(for: .normal) : nil
     }
 
     private var isVisible: Bool {

--- a/MVVM Module/Source/Feed UI/Views/Feed.storyboard
+++ b/MVVM Module/Source/Feed UI/Views/Feed.storyboard
@@ -39,6 +39,7 @@
                             </constraints>
                             <connections>
                                 <outlet property="label" destination="Tn7-ki-LHD" id="STB-t0-j55"/>
+                                <outletCollection property="gestureRecognizers" destination="uHs-oO-jhW" appends="YES" id="Nvw-PJ-g3T"/>
                             </connections>
                         </view>
                         <view key="tableFooterView" contentMode="scaleToFill" id="pGT-Qn-vv2">
@@ -168,6 +169,11 @@ Location</string>
                     </refreshControl>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RzX-Pc-Xwa" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="uHs-oO-jhW" userLabel="Hide Error Gesture Recognizer">
+                    <connections>
+                        <action selector="hideMessage" destination="clu-9B-M8g" id="xfH-cQ-zct"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="1105.7971014492755" y="-11.383928571428571"/>
         </scene>

--- a/MVVM Module/Source/Feed UI/Views/Feed.storyboard
+++ b/MVVM Module/Source/Feed UI/Views/Feed.storyboard
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1hh-nG-9OR">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1hh-nG-9OR">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,28 +19,30 @@
                             <rect key="frame" x="0.0" y="0.0" width="414" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tn7-ki-LHD">
-                                    <rect key="frame" x="0.0" y="8" width="414" height="18"/>
-                                    <viewLayoutGuide key="safeArea" id="zK7-Tw-quM"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WTg-rI-vrF">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="34"/>
+                                    <state key="normal" title="Error text">
+                                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </state>
+                                    <connections>
+                                        <action selector="hideMessage" destination="clu-9B-M8g" eventType="touchUpInside" id="rbx-13-EnF"/>
+                                    </connections>
+                                </button>
                             </subviews>
                             <color key="backgroundColor" red="1" green="0.41343292225631301" blue="0.54339731250950174" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
-                                <constraint firstAttribute="trailing" secondItem="Tn7-ki-LHD" secondAttribute="trailing" id="4tN-d3-RcV"/>
-                                <constraint firstAttribute="bottom" secondItem="Tn7-ki-LHD" secondAttribute="bottom" constant="8" id="8GQ-m8-52B"/>
-                                <constraint firstItem="Tn7-ki-LHD" firstAttribute="leading" secondItem="clu-9B-M8g" secondAttribute="leading" id="CAi-ql-iK7"/>
-                                <constraint firstItem="Tn7-ki-LHD" firstAttribute="top" secondItem="clu-9B-M8g" secondAttribute="top" constant="8" id="jGp-Jq-L6N"/>
+                                <constraint firstAttribute="bottom" secondItem="WTg-rI-vrF" secondAttribute="bottom" id="WhY-MK-8K4"/>
+                                <constraint firstItem="WTg-rI-vrF" firstAttribute="leading" secondItem="clu-9B-M8g" secondAttribute="leading" id="X3t-KS-nhm"/>
+                                <constraint firstAttribute="trailing" secondItem="WTg-rI-vrF" secondAttribute="trailing" id="jQn-qF-H7O"/>
+                                <constraint firstItem="WTg-rI-vrF" firstAttribute="top" secondItem="clu-9B-M8g" secondAttribute="top" id="kSX-W9-FN0"/>
                             </constraints>
                             <connections>
-                                <outlet property="label" destination="Tn7-ki-LHD" id="STB-t0-j55"/>
+                                <outlet property="button" destination="WTg-rI-vrF" id="inN-Gt-9Bg"/>
                                 <outletCollection property="gestureRecognizers" destination="uHs-oO-jhW" appends="YES" id="Nvw-PJ-g3T"/>
                             </connections>
                         </view>
                         <view key="tableFooterView" contentMode="scaleToFill" id="pGT-Qn-vv2">
-                            <rect key="frame" x="0.0" y="642" width="414" height="16"/>
+                            <rect key="frame" x="0.0" y="670" width="414" height="16"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>

--- a/MVVM Module/Source/Feed UI/Views/Feed.storyboard
+++ b/MVVM Module/Source/Feed UI/Views/Feed.storyboard
@@ -6,30 +6,49 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Feed View Controller-->
         <scene sceneID="mpX-1N-UIf">
             <objects>
-                <tableViewController id="1hh-nG-9OR" customClass="FeedViewController" customModule="EssentialFeediOS" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="1hh-nG-9OR" customClass="FeedViewController" customModule="MVVM" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="9C2-mb-zX4">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <view key="tableHeaderView" contentMode="scaleToFill" id="clu-9B-M8g">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="16"/>
+                        <view key="tableHeaderView" contentMode="scaleToFill" id="clu-9B-M8g" customClass="ErrorView" customModule="MVVM" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tn7-ki-LHD">
+                                    <rect key="frame" x="0.0" y="8" width="414" height="18"/>
+                                    <viewLayoutGuide key="safeArea" id="zK7-Tw-quM"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                            <color key="backgroundColor" red="1" green="0.41343292225631301" blue="0.54339731250950174" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            <constraints>
+                                <constraint firstAttribute="trailing" secondItem="Tn7-ki-LHD" secondAttribute="trailing" id="4tN-d3-RcV"/>
+                                <constraint firstAttribute="bottom" secondItem="Tn7-ki-LHD" secondAttribute="bottom" constant="8" id="8GQ-m8-52B"/>
+                                <constraint firstItem="Tn7-ki-LHD" firstAttribute="leading" secondItem="clu-9B-M8g" secondAttribute="leading" id="CAi-ql-iK7"/>
+                                <constraint firstItem="Tn7-ki-LHD" firstAttribute="top" secondItem="clu-9B-M8g" secondAttribute="top" constant="8" id="jGp-Jq-L6N"/>
+                            </constraints>
+                            <connections>
+                                <outlet property="label" destination="Tn7-ki-LHD" id="STB-t0-j55"/>
+                            </connections>
                         </view>
                         <view key="tableFooterView" contentMode="scaleToFill" id="pGT-Qn-vv2">
-                            <rect key="frame" x="0.0" y="624" width="414" height="16"/>
+                            <rect key="frame" x="0.0" y="642" width="414" height="16"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="FeedImageCell" rowHeight="580" id="4Aa-lg-gTp" customClass="FeedImageCell" customModule="EssentialFeediOS" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="44" width="414" height="580"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="FeedImageCell" rowHeight="580" id="4Aa-lg-gTp" customClass="FeedImageCell" customModule="MVVM" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="62" width="414" height="580"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="4Aa-lg-gTp" id="ZOf-kB-Mm6">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="580"/>

--- a/MVVM Module/Source/Feed UI/Views/Helpers/UIView+Shimmering.swift
+++ b/MVVM Module/Source/Feed UI/Views/Helpers/UIView+Shimmering.swift
@@ -15,7 +15,7 @@ extension UIView {
 		}
 		
 		get {
-			return layer.mask?.animation(forKey: shimmerAnimationKey) != nil
+			layer.mask?.animation(forKey: shimmerAnimationKey) != nil
 		}
 	}
 	

--- a/MVVM Module/Tests/Feed UI/FeedUIIntegrationTests.swift
+++ b/MVVM Module/Tests/Feed UI/FeedUIIntegrationTests.swift
@@ -91,6 +91,19 @@ final class FeedUIIntegrationTests: XCTestCase {
         XCTAssertEqual(sut.errorMessage, nil)
     }
 
+    func test_loadFeedCompletion_hidesErrorMessageOnErrorLabelTap() {
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoadingWithError(at: 0)
+
+        XCTAssertEqual(sut.errorMessage, localized("FEED_VIEW_CONNECTION_ERROR"))
+
+        sut.errorView?.button.simulateTap()
+
+        XCTAssertEqual(sut.errorMessage, nil)
+    }
+
 	func test_feedImageView_loadsImageURLWhenVisible() {
 		let image0 = makeImage(url: URL(string: "http://url-0.com")!)
 		let image1 = makeImage(url: URL(string: "http://url-1.com")!)

--- a/MVVM Module/Tests/Feed UI/FeedUIIntegrationTests.swift
+++ b/MVVM Module/Tests/Feed UI/FeedUIIntegrationTests.swift
@@ -78,6 +78,19 @@ final class FeedUIIntegrationTests: XCTestCase {
 		assertThat(sut, isRendering: [image0])
 	}
 
+    func test_loadFeedCompletion_rendersErrorMessageOnErrorUntilNextReload() {
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        XCTAssertEqual(sut.errorMessage, nil)
+
+        loader.completeFeedLoadingWithError(at: 0)
+        XCTAssertEqual(sut.errorMessage, localized("FEED_VIEW_CONNECTION_ERROR"))
+
+        sut.simulateUserInitiatedFeedReload()
+        XCTAssertEqual(sut.errorMessage, nil)
+    }
+
 	func test_feedImageView_loadsImageURLWhenVisible() {
 		let image0 = makeImage(url: URL(string: "http://url-0.com")!)
 		let image1 = makeImage(url: URL(string: "http://url-1.com")!)

--- a/MVVM Module/Tests/Feed UI/Helpers/FeedViewController+TestHelpers.swift
+++ b/MVVM Module/Tests/Feed UI/Helpers/FeedViewController+TestHelpers.swift
@@ -39,6 +39,11 @@ extension FeedViewController {
 		let index = IndexPath(row: row, section: feedImagesSection)
 		ds?.tableView?(tableView, cancelPrefetchingForRowsAt: [index])
 	}
+
+    var errorMessage: String? {
+        let errorView = tableView.tableHeaderView as? ErrorView
+        return errorView?.message
+    }
 	
 	var isShowingLoadingIndicator: Bool {
 		return refreshControl?.isRefreshing == true

--- a/UIDesignPatternsChallenge.xcodeproj/project.pbxproj
+++ b/UIDesignPatternsChallenge.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		08F3B6E2232258BD00510CE7 /* FeedUIIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F3B6D6232258BD00510CE7 /* FeedUIIntegrationTests.swift */; };
 		08F3B6E3232258BD00510CE7 /* FeedLocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F3B6D8232258BD00510CE7 /* FeedLocalizationTests.swift */; };
 		08F3B6E6232258CE00510CE7 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F3B6E5232258CE00510CE7 /* XCTestCase+MemoryLeakTracking.swift */; };
+		83B34366232554F100501640 /* UIView+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B34365232554F100501640 /* UIView+TestHelpers.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -317,6 +318,7 @@
 		83B343602325301100501640 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/Feed.strings; sourceTree = "<group>"; };
 		83B343612325301100501640 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/Feed.strings; sourceTree = "<group>"; };
 		83B343622325301200501640 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/Feed.strings; sourceTree = "<group>"; };
+		83B34365232554F100501640 /* UIView+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+TestHelpers.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -861,6 +863,7 @@
 				08F3B6D3232258BD00510CE7 /* UIControl+TestHelpers.swift */,
 				08F3B6D4232258BD00510CE7 /* FeedViewController+TestHelpers.swift */,
 				08F3B6D5232258BD00510CE7 /* UIRefreshControl+TestHelpers.swift */,
+				83B34365232554F100501640 /* UIView+TestHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1372,6 +1375,7 @@
 				08F3B6DC232258BD00510CE7 /* FeedUIIntegrationTests+Assertions.swift in Sources */,
 				08F3B6E6232258CE00510CE7 /* XCTestCase+MemoryLeakTracking.swift in Sources */,
 				08F3B6E2232258BD00510CE7 /* FeedUIIntegrationTests.swift in Sources */,
+				83B34366232554F100501640 /* UIView+TestHelpers.swift in Sources */,
 				08F3B6E1232258BD00510CE7 /* UIRefreshControl+TestHelpers.swift in Sources */,
 				08F3B6DD232258BD00510CE7 /* FeedImageCell+TestHelpers.swift in Sources */,
 				08F3B6DA232258BD00510CE7 /* FeedUIIntegrationTests+Localization.swift in Sources */,

--- a/UIDesignPatternsChallenge.xcodeproj/project.pbxproj
+++ b/UIDesignPatternsChallenge.xcodeproj/project.pbxproj
@@ -314,6 +314,9 @@
 		08F3B6D6232258BD00510CE7 /* FeedUIIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedUIIntegrationTests.swift; sourceTree = "<group>"; };
 		08F3B6D8232258BD00510CE7 /* FeedLocalizationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedLocalizationTests.swift; sourceTree = "<group>"; };
 		08F3B6E5232258CE00510CE7 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
+		83B343602325301100501640 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/Feed.strings; sourceTree = "<group>"; };
+		83B343612325301100501640 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/Feed.strings; sourceTree = "<group>"; };
+		83B343622325301200501640 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/Feed.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1130,6 +1133,7 @@
 				el,
 				"pt-BR",
 				Base,
+				ro,
 			);
 			mainGroup = 08F3B58B2322512F00510CE7;
 			productRefGroup = 08F3B5962322512F00510CE7 /* Products */;
@@ -1436,6 +1440,7 @@
 				08F3B5DD232252F300510CE7 /* el */,
 				08F3B5DE232252F300510CE7 /* en */,
 				08F3B5E0232252F300510CE7 /* pt-BR */,
+				83B343602325301100501640 /* ro */,
 			);
 			name = Feed.strings;
 			sourceTree = "<group>";
@@ -1446,6 +1451,7 @@
 				08F3B63F2322564500510CE7 /* el */,
 				08F3B6402322564500510CE7 /* en */,
 				08F3B6422322564500510CE7 /* pt-BR */,
+				83B343612325301100501640 /* ro */,
 			);
 			name = Feed.strings;
 			sourceTree = "<group>";
@@ -1456,6 +1462,7 @@
 				08F3B6A82322585E00510CE7 /* el */,
 				08F3B6A92322585E00510CE7 /* en */,
 				08F3B6AD2322585E00510CE7 /* pt-BR */,
+				83B343622325301200501640 /* ro */,
 			);
 			name = Feed.strings;
 			sourceTree = "<group>";


### PR DESCRIPTION
Hi, 

This is my proposal for MVVM and MVP.

For **MVVM**, I didn't create separated viewModel for the ErrorView, since it is inside the `tableView.tableHeaderView`. The same for **MVP**, I didn't create a separated errorPresenter for the same reason. Would you agree?

I could not make smaller commits becasue added the integration test `test_loadFeedCompletion_rendersErrorMessageOnErrorUntilNextReload` forced me commit more files at once.

The only thing I was not able to achieve was to simulate (trigger) the existing tap gesture on the ErrorView label. An alternative would be to change the inner `UILabel` to a `UIButton`, to have an `UIControl` (`UIButton`) instead of `UIResponder` (`UIView`) element on which I could use existing `simulateTap()` helper function. 

If you have any comments, thank you.

Mihai